### PR TITLE
input boxes now scaled correctly on schedule form

### DIFF
--- a/components/scheduleform/scheduleform.module.css
+++ b/components/scheduleform/scheduleform.module.css
@@ -85,6 +85,15 @@
   }
 }
 
+@media (min-width: 1441px) {
+  .scheduleForm input[type="text"],
+  .scheduleForm input[type="date"],
+  .scheduleForm input[type="time"],
+  .scheduleForm select {
+    width: 22.5vw;
+  }
+}
+
 .error {
   color: red;
 }


### PR DESCRIPTION
The input boxes on the schedule form should now be sized proportionately on all screens above 1440px!